### PR TITLE
Fix/missing pybind tools dep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
 
   <depend>behaviortree_cpp</depend>
   <depend>py_binding_tools</depend>
+  <depend>ament_mypy</depend>
   <depend>fmt</depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <depend>behaviortree_cpp</depend>
   <depend>py_binding_tools</depend>
-  <depend>ament_mypy</depend>
+  <depend>python3-mypy</depend>
   <depend>fmt</depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>behaviortree_cpp</depend>
+  <depend>py_binding_tools</depend>
   <depend>fmt</depend>
 
   <export>


### PR DESCRIPTION
Fixing dependency problems - WIP.

Missing deps: 
1. py_binding_tools
2. mypy (stubgen)

@JafarAbdi if you know how to fix it quicker or differently feel free to take over!